### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "files": [
     "dist"
   ],
-  "author": "David Khourshid <davidkpiano@gmail.com>",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/davidkpiano/xviz.git"
   },
+  "author": "David Khourshid <davidkpiano@gmail.com>",
   "license": "MIT",
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources. 

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR. 

Published NPM packages with repository information:
• xviz